### PR TITLE
フォームの問題データを返せるようにした。

### DIFF
--- a/formcoder-api/src/form/form.controller.ts
+++ b/formcoder-api/src/form/form.controller.ts
@@ -5,6 +5,7 @@ import { FormService } from './form.service';
 
 import { CodingFormData } from '../type/formData';
 import { FormList } from 'src/type/formList';
+import { Question } from 'src/type/question';
 
 @Controller('form')
 export class FormController {
@@ -31,6 +32,14 @@ export class FormController {
   @Get('/list')
   pullFormList(): Promise<{ formList: FormList[] }> {
     return this.formService.pullFormList();
+  }
+
+  //cloud firestoreからフォームの問題データをpullする
+  @Get('/question')
+  pullQuestionData(
+    @Query('formId') formId: string,
+  ): Promise<{ questionData: Question }> {
+    return this.formService.pullQuestionData(formId);
   }
 
   @Get('/hello')

--- a/formcoder-api/src/form/form.service.ts
+++ b/formcoder-api/src/form/form.service.ts
@@ -161,6 +161,10 @@ export class FormService {
 
   //cloud firestoreから指定されたフォームIDの問題データをpullする
   pullQuestionData(formId: string): Promise<{ questionData: Question }> {
+    if (formId === undefined) {
+      const errMessage = 'パラメータformIdは必須です。';
+      throw new HttpException(errMessage, 400);
+    }
     try {
       const docRef = this.firestore.collection('form-list').doc(formId);
       return new Promise<{ questionData: Question }>((resolve, reject) => {

--- a/formcoder-api/src/form/form.service.ts
+++ b/formcoder-api/src/form/form.service.ts
@@ -5,6 +5,7 @@ import { Firestore } from '@google-cloud/firestore';
 
 import { CodingFormData } from '../type/formData';
 import { FormList } from 'src/type/formList';
+import { Question } from 'src/type/question';
 
 dotenv.config();
 
@@ -144,6 +145,41 @@ export class FormService {
               reject(new HttpException(errMessage, 404));
             }
             resolve({ formList: formList });
+          })
+          .catch((err) => {
+            const errMessage = 'プル時にエラーが発生しました！';
+            console.log(err.message);
+            reject(new HttpException(errMessage, 500));
+          });
+      });
+    } catch (error) {
+      const errMessage = '何らかのエラーが発生しました。';
+      console.log(error.message);
+      throw new HttpException(errMessage, 500);
+    }
+  }
+
+  //cloud firestoreから指定されたフォームIDの問題データをpullする
+  pullQuestionData(formId: string): Promise<{ questionData: Question }> {
+    try {
+      const docRef = this.firestore.collection('form-list').doc(formId);
+      return new Promise<{ questionData: Question }>((resolve, reject) => {
+        docRef
+          .get()
+          .then((doc) => {
+            if (!doc.exists) {
+              const errMessage =
+                '指定されたフォームIDのデータが見つかりません。';
+              reject(new HttpException(errMessage, 404));
+            }
+            const questionData: Question = {
+              id: doc.id,
+              title: doc.data().title,
+              explanation: doc.data().explanation,
+              inputExample: doc.data().inputExample,
+              outputExample: doc.data().outputExample,
+            };
+            resolve({ questionData: questionData });
           })
           .catch((err) => {
             const errMessage = 'プル時にエラーが発生しました！';

--- a/formcoder-api/src/form/form.service.ts
+++ b/formcoder-api/src/form/form.service.ts
@@ -128,7 +128,16 @@ export class FormService {
           .then((snapshot) => {
             const formList: FormList[] = [];
             snapshot.forEach((doc) => {
-              formList.push(doc.data() as FormList);
+              const form = {
+                id: doc.id,
+                title: doc.data().title,
+                description: doc.data().description,
+                url: doc.data().url,
+                explanation: doc.data().explanation,
+                inputExample: doc.data().inputExample,
+                outputExample: doc.data().outputExample,
+              };
+              formList.push(form);
             });
             if (formList.length === 0) {
               const errMessage = 'フォームリストが空です。';

--- a/formcoder-api/src/type/formList.ts
+++ b/formcoder-api/src/type/formList.ts
@@ -1,5 +1,5 @@
 export type FormList = {
-  id: number;
+  id: string;
   title: string;
   description: string;
   url: string;

--- a/formcoder-api/src/type/formList.ts
+++ b/formcoder-api/src/type/formList.ts
@@ -3,4 +3,7 @@ export type FormList = {
   title: string;
   description: string;
   url: string;
+  explanation: string;
+  inputExample: string[];
+  outputExample: string[];
 };

--- a/formcoder-api/src/type/question.ts
+++ b/formcoder-api/src/type/question.ts
@@ -1,0 +1,7 @@
+export type Question = {
+  id: string;
+  title: string;
+  explanation: string;
+  inputExample: string[];
+  outputExample: string[];
+};


### PR DESCRIPTION
# 変更
* `/form/list`のエンドポイントにおいて、問題データを一緒に返せるようにした。
* 問題データを返す`/form/question`エンドポイントとその関数を作成した。
* 上記２つで扱うIDは、firestoreのドキュメントIDを使用するようにした。

# issue
closed #37 
