### PR TITLE
学習取り組み情報をFirestoreに記録できるようにした。

### DIFF
--- a/formcoder-api/src/record/record.controller.ts
+++ b/formcoder-api/src/record/record.controller.ts
@@ -14,7 +14,7 @@ export class RecordController {
   @Post('/')
   pushAnswerData(
     @Body() recordInputDto: RecordInputDto,
-  ): Promise<{ message: string }> {
+  ): Promise<{ message: string; recordId: string }> {
     return this.recordService.pushAnswerData(recordInputDto);
   }
 


### PR DESCRIPTION
# 変更
* 関数`pushAnswerData`に、記録ファイルの情報とユーザー情報に関する記録をFirestoreに記録できるように処理を追加した。
* パス`/record`の成功時のレスポンスに、作成された取り組み記録のIDを返すように追加した。

# issue
closed #67 